### PR TITLE
Feat/test goo

### DIFF
--- a/src/main/java/com/app/domain/categorizedProblem/dto/CategorizedProblemDto.java
+++ b/src/main/java/com/app/domain/categorizedProblem/dto/CategorizedProblemDto.java
@@ -12,8 +12,11 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.util.Comparator;
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 public class CategorizedProblemDto {
 
@@ -76,9 +79,21 @@ public class CategorizedProblemDto {
             ResponseBuilder builder = Response.builder()
                     .categorizedProblemId(categorizedProblem.getCategorizedProblemId());
 
-            List<CategorizedProblemResponse> categorizedProblemResponses = categorizedProblem.getCategory().getCategorizedProblems()
-                    .stream()
+            List<CategorizedProblem> problems = categorizedProblem.getCategory().getCategorizedProblems();
+            CategorizedProblem previousProblem = problems.stream()
+                    .filter(cp -> cp.getCategorizedProblemId() < categorizedProblem.getCategorizedProblemId())
+                    .max(Comparator.comparing(CategorizedProblem::getCategorizedProblemId))
+                    .orElse(null);
+
+            CategorizedProblem nextProblem = problems.stream()
+                    .filter(cp -> cp.getCategorizedProblemId() > categorizedProblem.getCategorizedProblemId())
+                    .min(Comparator.comparing(CategorizedProblem::getCategorizedProblemId))
+                    .orElse(null);
+
+
+            List<CategorizedProblemResponse> categorizedProblemResponses = Stream.of(previousProblem, nextProblem)
                     .map(CategorizedProblemResponse::of)
+                    .filter(Objects::nonNull)
                     .collect(Collectors.toList());
 
             if(categorizedProblem.getMemberSavedProblem() != null){
@@ -114,10 +129,6 @@ public class CategorizedProblemDto {
 
         @JsonProperty("isWriter")
         private Boolean isWriter;
-
-        public Boolean getisWriter() {
-            return isWriter;
-        }
     }
 
     @Getter

--- a/src/main/java/com/app/domain/categorizedProblem/dto/CategorizedProblemDto.java
+++ b/src/main/java/com/app/domain/categorizedProblem/dto/CategorizedProblemDto.java
@@ -76,8 +76,6 @@ public class CategorizedProblemDto {
         private List<CategorizedProblemResponse> categorizedProblems;
 
         public static Response of(CategorizedProblem categorizedProblem) {
-            ResponseBuilder builder = Response.builder()
-                    .categorizedProblemId(categorizedProblem.getCategorizedProblemId());
 
             List<CategorizedProblem> problems = categorizedProblem.getCategory().getCategorizedProblems();
             CategorizedProblem previousProblem = problems.stream()
@@ -95,6 +93,9 @@ public class CategorizedProblemDto {
                     .map(CategorizedProblemResponse::of)
                     .filter(Objects::nonNull)
                     .collect(Collectors.toList());
+
+            ResponseBuilder builder = Response.builder()
+                    .categorizedProblemId(categorizedProblem.getCategorizedProblemId());
 
             if(categorizedProblem.getMemberSavedProblem() != null){
                 MemberSavedProblem memberSavedProblem = categorizedProblem.getMemberSavedProblem();

--- a/src/main/java/com/app/domain/categorizedProblem/service/CategorizedProblemService.java
+++ b/src/main/java/com/app/domain/categorizedProblem/service/CategorizedProblemService.java
@@ -222,7 +222,7 @@ public class CategorizedProblemService {
 
     public CategorizedProblem updateCategorizedProblem(Long categorizedProblemId, MemberSavedProblemDto.Patch problemPatchDto) {
         CategorizedProblem categorizedProblem = findVerifiedCategorizedProblemByCategorizedProblemId(categorizedProblemId);
-        if(categorizedProblem.getMemberSavedProblem().getMemberSavedProblemId() != null){
+        if(categorizedProblem.getMemberSavedProblem() != null){
             memberSavedProblemService.updateProblem(memberSavedProblemMapper.
                     problemPatchDtoToProblem(problemPatchDto), categorizedProblem.getMemberSavedProblem().getMemberSavedProblemId());
         }

--- a/src/main/java/com/app/domain/categorizedSummary/entity/CategorizedSummary.java
+++ b/src/main/java/com/app/domain/categorizedSummary/entity/CategorizedSummary.java
@@ -25,6 +25,7 @@ public class CategorizedSummary extends BaseEntity {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "CATEGORY_ID", nullable = false)
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private Category category;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/app/domain/categorizedSummary/service/CategorizedSummaryService.java
+++ b/src/main/java/com/app/domain/categorizedSummary/service/CategorizedSummaryService.java
@@ -67,7 +67,7 @@ public class CategorizedSummaryService {
 
     public CategorizedSummary updateCategorizedSummary(Long categorizedSummaryId, MemberSavedSummaryDto.Patch summaryPatchDto) {
         CategorizedSummary categorizedSummary = findVerifiedCategorizedSummaryByCategorizedSummaryId(categorizedSummaryId);
-        if (categorizedSummary.getMemberSavedSummary().getMemberSavedSummaryId() != null) {
+        if (categorizedSummary.getMemberSavedSummary() != null) {
             memberSavedSummaryService.updateSummary(memberSavedSummaryMapper.
                     summaryPatchDtoToSummary(summaryPatchDto), categorizedSummary.getMemberSavedSummary().getMemberSavedSummaryId());
         }

--- a/src/main/java/com/app/domain/category/service/CategoryService.java
+++ b/src/main/java/com/app/domain/category/service/CategoryService.java
@@ -11,6 +11,7 @@ import com.app.global.error.exception.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -56,7 +57,7 @@ public class CategoryService {
 
     @Transactional(readOnly = true)
     public Page<Category> findCategoriesByMemberIdAndType(int page, int size, CategoryType categoryType, HttpServletRequest httpServletRequest) {
-        PageRequest pageRequest = PageRequest.of(page, size);
+        PageRequest pageRequest = PageRequest.of(page, size, Sort.by("categoryName"));
         Member member = memberService.getLoginMember(httpServletRequest);
 
         return categoryRepository.findByMemberMemberIdAndCategoryType(member.getMemberId(), categoryType, pageRequest);


### PR DESCRIPTION
1. 카테고리 내부에 카테고리별 요점정리가 존재할 때 카테고리가 수정되지 않던 에러 해결

2. 카테고리 정렬 순서 변경 전: 생성 순서 --> 변경 후: 영어~한글 오름차순

3. 카테고리별 요점정리/카테고리별 문제 조회 API, 수정 API 응답 데이터 구조 수정
변경 전: 해당 카테고리에 포함된 모든 요점정리/문제의 ID 및 name 반환
변경 후: 해당 카테고리에서 현재 조회 중인 id값 기준 작은 id값 1개, 큰 id값 1개의 ID 및 name 반환